### PR TITLE
Fix get appointments donor id

### DIFF
--- a/backend/app/db/sqlc/appointment.py
+++ b/backend/app/db/sqlc/appointment.py
@@ -39,7 +39,7 @@ SELECT a.id as id,
     a.cancelled,
     COALESCE(n.nl, '[]'\\:\\:json) as notes
 FROM appointment a
-INNER JOIN "user" u on a.donor_id = u.id
+INNER JOIN "user" u on a.donor_id = u.donor_id
 INNER JOIN bookingslot b on a.bookingslot_id = b.id
 INNER JOIN bloodbank ba on b.bloodbank_id = ba.id
 LEFT JOIN notes n ON n.appointment_id = a.id

--- a/backend/db/queries/appointment.sql
+++ b/backend/db/queries/appointment.sql
@@ -19,7 +19,7 @@ SELECT a.id as id,
     a.cancelled,
     COALESCE(n.nl, '[]'::json) as notes
 FROM appointment a
-INNER JOIN "user" u on a.donor_id = u.id
+INNER JOIN "user" u on a.donor_id = u.donor_id
 INNER JOIN bookingslot b on a.bookingslot_id = b.id
 INNER JOIN bloodbank ba on b.bloodbank_id = ba.id
 LEFT JOIN notes n ON n.appointment_id = a.id


### PR DESCRIPTION
There was a bug where get appointments by donor id joined in user on matching user and donor ids, these are not the same series